### PR TITLE
[WIP] Add MetadataLite to Table to avoid unnecessary API requests

### DIFF
--- a/bigquery/dataset.go
+++ b/bigquery/dataset.go
@@ -339,10 +339,11 @@ func (it *TableIterator) fetch(pageSize int, pageToken string) (string, error) {
 	}
 	for _, t := range res.Tables {
 		table := bqToTable(t.TableReference, it.dataset.c)
-		table.Type = TableType(t.Type)
-		table.Description = t.Description
+		tableType := TableType(t.Type)
+		table.Type = &tableType
+		table.Description = &t.Description
 		if t.View != nil {
-			table.UseLegacySQL = t.View.UseLegacySql
+			table.UseLegacySQL = &t.View.UseLegacySql
 		}
 		it.tables = append(it.tables, table)
 	}

--- a/bigquery/dataset.go
+++ b/bigquery/dataset.go
@@ -339,12 +339,10 @@ func (it *TableIterator) fetch(pageSize int, pageToken string) (string, error) {
 	}
 	for _, t := range res.Tables {
 		table := bqToTable(t.TableReference, it.dataset.c)
-		table.meta = &TableMetadataLite{
-			Type:        TableType(t.Type),
-			Description: t.Description,
-		}
+		table.Type = TableType(t.Type)
+		table.Description = t.Description
 		if t.View != nil {
-			table.meta.UseLegacySQL = t.View.UseLegacySql
+			table.UseLegacySQL = t.View.UseLegacySql
 		}
 		it.tables = append(it.tables, table)
 	}

--- a/bigquery/dataset.go
+++ b/bigquery/dataset.go
@@ -338,7 +338,15 @@ func (it *TableIterator) fetch(pageSize int, pageToken string) (string, error) {
 		return "", err
 	}
 	for _, t := range res.Tables {
-		it.tables = append(it.tables, bqToTable(t.TableReference, it.dataset.c))
+		table := bqToTable(t.TableReference, it.dataset.c)
+		table.meta = &TableMetadataLite{
+			Type:        TableType(t.Type),
+			Description: t.Description,
+		}
+		if t.View != nil {
+			table.meta.UseLegacySQL = t.View.UseLegacySql
+		}
+		it.tables = append(it.tables, table)
 	}
 	return res.NextPageToken, nil
 }

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -35,14 +35,11 @@ type Table struct {
 	// The maximum length is 1,024 characters.
 	TableID string
 
-	c    *Client
-	meta *TableMetadataLite
-}
-
-type TableMetadataLite struct {
 	Description  string
 	UseLegacySQL bool
 	Type         TableType
+
+	c *Client
 }
 
 // TableMetadata contains information about a BigQuery table.
@@ -378,27 +375,6 @@ func (tm *TableMetadata) toBQ() (*bq.Table, error) {
 	return t, nil
 }
 
-func (t *Table) MetadataLite(ctx context.Context) (md *TableMetadataLite, err error) {
-	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigquery.Table.Metadata")
-	defer func() { trace.EndSpan(ctx, err) }()
-
-	if t.meta != nil {
-		return t.meta, nil
-	}
-
-	req := t.c.bqs.Tables.Get(t.ProjectID, t.DatasetID, t.TableID).Context(ctx)
-	setClientHeader(req.Header())
-	var table *bq.Table
-	err = runWithRetry(ctx, func() (err error) {
-		table, err = req.Do()
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return bqToTableMetadataLite(table), nil
-}
-
 // Metadata fetches the metadata for the table.
 func (t *Table) Metadata(ctx context.Context) (md *TableMetadata, err error) {
 	ctx = trace.StartSpan(ctx, "cloud.google.com/go/bigquery.Table.Metadata")
@@ -415,17 +391,6 @@ func (t *Table) Metadata(ctx context.Context) (md *TableMetadata, err error) {
 		return nil, err
 	}
 	return bqToTableMetadata(table)
-}
-
-func bqToTableMetadataLite(t *bq.Table) *TableMetadataLite {
-	md := &TableMetadataLite{
-		Description: t.Description,
-		Type:        TableType(t.Type),
-	}
-	if t.View != nil {
-		md.UseLegacySQL = t.View.UseLegacySql
-	}
-	return md
 }
 
 func bqToTableMetadata(t *bq.Table) (*TableMetadata, error) {

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -35,6 +35,7 @@ type Table struct {
 	// The maximum length is 1,024 characters.
 	TableID string
 
+	// These fields are populated only when the Table was created from a table list API call.
 	Description  *string
 	UseLegacySQL *bool
 	Type         *TableType

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -35,9 +35,9 @@ type Table struct {
 	// The maximum length is 1,024 characters.
 	TableID string
 
-	Description  string
-	UseLegacySQL bool
-	Type         TableType
+	Description  *string
+	UseLegacySQL *bool
+	Type         *TableType
 
 	c *Client
 }


### PR DESCRIPTION
A bit hacky, but allows us to get the table metadata we need without an extra api request for each table, with minimal changes.